### PR TITLE
enable CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,4 @@ jobs:
               run: |
                 swift --version
                 swift build
+                swift build -c release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
     push:
-        branches: [ main ]
+        branches: [ master ]
     pull_request:
-        branches: [ main ]
+        branches: [ master ]
 
 jobs:
     build-macos:


### PR DESCRIPTION
we should build the package in release mode as well, to ensure we catch `-O`-only compiler crashers