### PR TITLE
validate documentation, and update Swift 5.10 → 5.10.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
           - uses: actions/checkout@v3
           - uses: SwiftyLab/setup-swift@latest
             with:
-              swift-version: "5.10.0"
+              swift-version: "5.10.1"
           - name: build
             run: |
               swift --version
@@ -26,7 +26,7 @@ jobs:
           - uses: actions/checkout@v3
           - uses: SwiftyLab/setup-swift@latest
             with:
-              swift-version: "5.10.0"
+              swift-version: "5.10.1"
           - name: Homebrew Mac
             if: ${{ runner.os == 'Macos' }}
             run: |
@@ -42,15 +42,14 @@ jobs:
               swift package benchmark
 
     build-linux:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@v3
             - uses: SwiftyLab/setup-swift@latest
               with:
-                swift-version: "5.10.0"
+                swift-version: "5.10.1"
             - name: build
               run: |
                 swift --version
-                swift build
                 swift build -c release
                 swift test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,46 +10,49 @@ jobs:
     build-macos:
         runs-on: macos-14
         steps:
-          - uses: actions/checkout@v3
-          - uses: SwiftyLab/setup-swift@latest
-            with:
-              swift-version: "5.10.1"
-          - name: build
-            run: |
-              swift --version
-              swift build
-              swift test
+            -   name: Checkout repository
+                uses: actions/checkout@v3
+
+            -   name: build
+                run: |
+                    swift --version
+                    swift build
+                    swift test
 
     benchmark-macos:
         runs-on: macos-14
         steps:
-          - uses: actions/checkout@v3
-          - uses: SwiftyLab/setup-swift@latest
-            with:
-              swift-version: "5.10.1"
-          - name: Homebrew Mac
-            if: ${{ runner.os == 'Macos' }}
-            run: |
-              echo "/opt/homebrew/bin:/usr/local/bin" >> $GITHUB_PATH
-              brew install jemalloc
-          - name: Ubuntu deps
-            if: ${{ runner.os == 'Linux' }}
-            run: |
-              sudo apt-get install -y libjemalloc-dev
-          - name: benchmark
-            run: |
-              cd ExternalBenchmarks
-              swift package benchmark
+            -   name: Checkout repository
+                uses: actions/checkout@v3
+
+            -   name: Homebrew Mac
+                if: ${{ runner.os == 'Macos' }}
+                run: |
+                    echo "/opt/homebrew/bin:/usr/local/bin" >> $GITHUB_PATH
+                    brew install jemalloc
+            -   name: Ubuntu deps
+                if: ${{ runner.os == 'Linux' }}
+                run: |
+                    sudo apt-get install -y libjemalloc-dev
+            -   name: benchmark
+                run: |
+                    cd ExternalBenchmarks
+                    swift package benchmark
 
     build-linux:
         runs-on: ubuntu-24.04
         steps:
-            - uses: actions/checkout@v3
-            - uses: SwiftyLab/setup-swift@latest
-              with:
-                swift-version: "5.10.1"
-            - name: build
-              run: |
-                swift --version
-                swift build -c release
-                swift test
+            -   name: Install Swift
+                uses: tayloraswift/swift-install-action@master
+                with:
+                    swift-prefix: "swift-5.10.1-release/ubuntu2404/swift-5.10.1-RELEASE"
+                    swift-id: "swift-5.10.1-RELEASE-ubuntu24.04"
+
+            -   name: Checkout repository
+                uses: actions/checkout@v3
+
+            -   name: Build and test
+                run: |
+                    swift --version
+                    swift build -c release
+                    swift test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,59 @@
+# This workflow validates the package’s documentation. Because documentation building involves
+# compiling the package, this also checks that the package itself compiles successfully on each
+# supported platform.
+name: documentation
+
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
+
+jobs:
+    linux:
+        runs-on: ubuntu-24.04
+        name: Ubuntu 24.04
+
+        steps:
+            -   name: Install Swift
+                uses: tayloraswift/swift-install-action@master
+                with:
+                    swift-prefix: "swift-5.10.1-release/ubuntu2404/swift-5.10.1-RELEASE"
+                    swift-id: "swift-5.10.1-RELEASE-ubuntu24.04"
+
+            -   name: Install Unidoc
+                uses: tayloraswift/swift-unidoc-action@master
+                with:
+                    unidoc-version: "master"
+
+            #   This clobbers everything in the current directory!
+            -   name: Checkout repository
+                uses: actions/checkout@v3
+
+            -   name: Validate documentation
+                run: |
+                    unidoc compile -I .. \
+                    --swift-toolchain $SWIFT_INSTALLATION \
+                    --ci fail-on-errors \
+                    --package-name swift-noise
+
+    macos:
+        runs-on: macos-14
+        name: macOS
+        env:
+            DEVELOPER_DIR: "/Applications/Xcode_15.3.app/Contents/Developer"
+
+        steps:
+            -   name: Install Unidoc
+                uses: tayloraswift/swift-unidoc-action@master
+                with:
+                    unidoc-version: "master"
+
+            -   name: Checkout repository
+                uses: actions/checkout@v3
+
+            -   name: Validate documentation
+                run: |
+                    unidoc compile -I .. \
+                    --ci fail-on-errors \
+                    --package-name swift-noise

--- a/ExternalBenchmarks/Package.swift
+++ b/ExternalBenchmarks/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "ExternalBenchmarks",
     platforms: [
-        .macOS(.v13),
+        .macOS("13.3"),
     ],
     dependencies: [
         .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "1.0.0")),

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "swift-hash",
-        "repositoryURL": "https://github.com/tayloraswift/swift-hash",
-        "state": {
-          "branch": null,
-          "revision": "c7ba0cde5eb63042c2196b02b65a770101c1ac11",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "swift-png",
-        "repositoryURL": "https://github.com/tayloraswift/swift-png",
-        "state": {
-          "branch": null,
-          "revision": "14a720bfcf1b0660dc63979d55d218babc8d651f",
-          "version": "4.4.2"
-        }
+  "pins" : [
+    {
+      "identity" : "swift-hash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tayloraswift/swift-hash",
+      "state" : {
+        "revision" : "7a3fbb75ec4c88421796faaf0b47f16ffc21b348",
+        "version" : "0.6.2"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "swift-png",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tayloraswift/swift-png",
+      "state" : {
+        "revision" : "99c1279148c0843328263b39158bf10ea7ea469e",
+        "version" : "4.4.4"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -4,17 +4,17 @@ import PackageDescription
 
 let package = Package(
     name: "swift-noise",
-    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
-    products: 
+    platforms: [.macOS("13.3"), .iOS("16.4"), .tvOS("16.4"), .watchOS("9.4")],
+    products:
     [
         .library(name: "Noise", targets: ["Noise"]),
         .executable(name: "generate-noise", targets: ["GenNoise"])
     ],
-    dependencies: 
+    dependencies:
     [
         .package(url: "https://github.com/tayloraswift/swift-png", from: "4.4.0")
     ],
-    targets: 
+    targets:
     [
         .target(
             name: "Noise"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ***`noise`***<br>`2.0`
 
 [![ci build status](https://github.com/tayloraswift/swift-noise/actions/workflows/build.yml/badge.svg)](https://github.com/tayloraswift/swift-noise/actions/workflows/build.yml)
+[![ci build status](https://github.com/tayloraswift/swift-noise/actions/workflows/docs.yml/badge.svg)](https://github.com/tayloraswift/swift-noise/actions/workflows/docs.yml)
+
 [![swift package index versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ftayloraswift%2Fswift-noise%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/tayloraswift/swift-noise)
 [![swift package index platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ftayloraswift%2Fswift-noise%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/tayloraswift/swift-noise)
 

--- a/Sources/Noise/cell.swift
+++ b/Sources/Noise/cell.swift
@@ -565,7 +565,7 @@ extension _CellNoise3D
 /// `CellNoise3D` is analogous to
 /// [Blender Voronoi noise](https://docs.blender.org/manual/en/dev/render/cycles/nodes/types/textures/voronoi.html),
 /// with the *Distance Squared* metric. The *Scale* of Blender Voronoi noise is identical to the
-/// ``frequency`` of `CellNoise3D`; its range is approximately `0 ... 10/3` in `CellNoise3D`
+/// frequency of `CellNoise3D`; its range is approximately `0 ... 10/3` in `CellNoise3D`
 /// units.
 public
 struct CellNoise3D:_CellNoise3D, HashedNoise


### PR DESCRIPTION
this PR does three major changes:

1. it adds a Unidoc validation workflow that checks the integrity of the package’s documentation
2. it removes SwiftyLab/setup-swift from the CI workflows, as the action does not appear to have the most recent 5.10.1 Swift toolchain. on Linux, i replaced it with [tayloraswift/swift-install-action](https://github.com/tayloraswift/swift-install-action), and on macOS the CI now uses whatever default toolchain is installed on the macOS 14 runner.
3. it lifts the package-wide platform minimums in the Package.swift to macOS 13.3; the bottleneck is the `GenNoise` product which depends on swift-png. unfortunately i’m not aware of any [SwiftPM support](https://forums.swift.org/t/platform-per-target/29253/11) for per-target platform minimums, so this affects the entire package. 